### PR TITLE
Vector methods & WCSTransform attributes

### DIFF
--- a/src/WCS.jl
+++ b/src/WCS.jl
@@ -387,11 +387,12 @@ pix_to_world(wcs, pixcoords)
 
 Convert the array of pixel coordinates `pixcoords` to world coordinates
 according to the WCSTransform `wcs`. `pixcoords` should be a 2-d array
-where \"pixcoords[:, i]\" is the i-th set of coordinates.
+where \"pixcoords[:, i]\" is the i-th set of coordinates, or a 1-d array
+representing a single set of coordinates.
 
 The return value is the same shape as `pixcoords`.
 """
-pix_to_world(wcs::WCSTransform, pixcoords::Matrix{Float64}) =
+pix_to_world(wcs::WCSTransform, pixcoords::VecOrMat{Float64}) =
     pix_to_world!(wcs, pixcoords, similar(pixcoords))
 
 
@@ -401,7 +402,8 @@ pix_to_world!(wcs, pixcoords, worldcoords[; stat=, imcoords=, phi=, theta=])
 Convert the array of pixel coordinates `pixcoords` to world coordinates
 according to the WCSTransform `wcs`, storing the result in the
 `worldcoords` and `stat` arrays. `pixcoords` should be a 2-d array where
-\"pixcoords[:, i]\" is the i-th set of coordinates. `worldcoords` must be
+\"pixcoords[:, i]\" is the i-th set of coordinates, or a 1-d array
+representing a single set of coordinates. `worldcoords` must be
 the same size and type as `pixcoords`.
 
 If given, the arrays `stat`, `imcoords`, `phi`, `theta` will be used
@@ -409,13 +411,14 @@ to store intermediate results. Their sizes and types must all match
 `pixcoords`, except for `stat` which should be the same size but of type
 Cint (typically Int32).
 """
-function pix_to_world!(wcs::WCSTransform, pixcoords::Matrix{Float64},
-                       worldcoords::Matrix{Float64};
-                       stat::Matrix{Cint}=similar(pixcoords, Cint),
-                       imcoords::Matrix{Float64}=similar(pixcoords),
-                       phi::Matrix{Float64}=similar(pixcoords),
-                       theta::Matrix{Float64}=similar(pixcoords))
-    (nelem, ncoords) = size(pixcoords)
+function pix_to_world!(wcs::WCSTransform, pixcoords::VecOrMat{Float64},
+                       worldcoords::VecOrMat{Float64};
+                       stat=similar(pixcoords, Cint),
+                       imcoords=similar(pixcoords),
+                       phi=similar(pixcoords),
+                       theta=similar(pixcoords))
+    nelem = size(pixcoords, 1)
+    ncoords = size(pixcoords, 2)
     if nelem < wcs.naxis
         error("size(pixcoords, 1) must be greater than or equal to naxis")
     end
@@ -433,16 +436,18 @@ function pix_to_world!(wcs::WCSTransform, pixcoords::Matrix{Float64},
 end
 
 
+
 """
 world_to_pix(wcs, worldcoords)
 
 Convert the array of world coordinates `worldcoords` to pixel coordinates
-according to the WCSTransform `wcs`. `worldcoords` should be a 2-d array
-where \"worldcoords[:, i]\" is the i-th set of coordinates.
+according to the WCSTransform `wcs`. `worldcoords` is a 2-d array
+where \"worldcoords[:, i]\" is the i-th set of coordinates, or a 1-d array
+representing a single set of coordinates.
 
 The return value is the same size as `worldcoords`.
 """
-world_to_pix(wcs::WCSTransform, worldcoords::Matrix{Float64}) =
+world_to_pix(wcs::WCSTransform, worldcoords::VecOrMat{Float64}) =
     world_to_pix!(wcs, worldcoords, similar(worldcoords))
 
 
@@ -452,7 +457,8 @@ world_to_pix!(wcs, worldcoords, pixcoords[; stat=, phi=, theta=, imcoords=])
 Convert the array of pixel coordinates `worldcoords` to pixel coordinates
 according to the WCSTransform `wcs`, storing the result in the
 `pixcoords` array. `worldcoords` should be a 2-d array where
-\"worldcoords[:, i]\" is the i-th set of coordinates. `pixcoords` must be
+\"worldcoords[:, i]\" is the i-th set of coordinates, or a 1-d array
+representing a single set of coordinates. `pixcoords` must be
 the same size and type as `worldcoords`.
 
 If given, the arrays `stat`, `imcoords`, `phi`, `theta` will be used
@@ -460,13 +466,14 @@ to store intermediate results. Their sizes and types must all match
 `worldcoords`, except for `stat` which should be the same size but of type
 Cint (typically Int32).
 """
-function world_to_pix!(wcs::WCSTransform, worldcoords::Matrix{Float64},
-                       pixcoords::Matrix{Float64};
-                       stat::Matrix{Cint}=similar(pixcoords, Cint),
-                       phi::Matrix{Float64}=similar(pixcoords),
-                       theta::Matrix{Float64}=similar(pixcoords),
-                       imcoords::Matrix{Float64}=similar(pixcoords))
-    (nelem, ncoords) = size(worldcoords)
+function world_to_pix!(wcs::WCSTransform, worldcoords::VecOrMat{Float64},
+                       pixcoords::VecOrMat{Float64};
+                       stat=similar(pixcoords, Cint),
+                       phi=similar(pixcoords),
+                       theta=similar(pixcoords),
+                       imcoords=similar(pixcoords))
+    nelem = size(worldcoords, 1)
+    ncoords = size(worldcoords, 2)
     if nelem < wcs.naxis
         error("size(worldcoords, 1) must be greater than or equal to naxis")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+#!/usr/bin/env julia
+
 using WCS
 using Base.Test
 
@@ -13,7 +15,6 @@ wcs = WCSTransform(2;
                    pv      = [(2, 1, 45.0)],
                    velangl = 3,
                    wcsname = "WCSLIB.jl")
-#@test wcsset(w) == 0
 
 pixcoords = [0.0 24.0 45.0;  # x coords
              0.0 38.0 98.0]  # y coords
@@ -26,6 +27,12 @@ expected_world = [267.96547027 276.53931377 287.77080792;
 @test maximum(abs(worldcoords .- expected_world)) < 5e-9
 pixcoords_out = world_to_pix(wcs, worldcoords)
 @test maximum(abs(pixcoords_out .- pixcoords)) < 1e-9
+
+# Test Array{Float64, 1} methods of above
+worldcoords = pix_to_world(wcs, pixcoords[:, 1])
+@test maximum(abs(worldcoords .- expected_world[:, 1])) < 5e-9
+pixcoords_out = world_to_pix(wcs, worldcoords)
+@test maximum(abs(pixcoords_out .- pixcoords[:, 1])) < 1e-9
 
 header = "SIMPLE  =                    T / file does conform to FITS standard             BITPIX  =                  -64 / number of bits per data pixel                  NAXIS   =                    2 / number of data axes                            NAXIS1  =                 3636 / length of data axis 1                          NAXIS2  =                 1939 / length of data axis 2                          EXTEND  =                    T / FITS dataset may contain extensions            COMMENT   FITS (Flexible Image Transport System) format is defined in 'AstronomyCOMMENT   and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H WCSAXES =                    2 / Number of coordinate axes                      CRPIX1  =               1818.0 / Pixel coordinate of reference point            CRPIX2  =                969.5 / Pixel coordinate of reference point            CDELT1  =             -0.00825 / [deg] Coordinate increment at reference point  CDELT2  =              0.00825 / [deg] Coordinate increment at reference point  CUNIT1  = 'deg'                / Units of coordinate increment and value        CUNIT2  = 'deg'                / Units of coordinate increment and value        CTYPE1  = 'RA---CEA'           / Right ascension, cylindrical equal area projectCTYPE2  = 'DEC--CEA'           / Declination, cylindrical equal area projection CRVAL1  =            3.575E+02 / [deg] Coordinate value at reference point      CRVAL2  =            0.000E+00 / [deg] Coordinate value at reference point      PV2_1   =                  1.0 / CEA projection parameter                       LONPOLE =                  0.0 / [deg] Native longitude of celestial pole       LATPOLE =                 90.0 / [deg] Native latitude of celestial pole        RADESYS = 'ICRS'               / Equatorial coordinate system                                                                                                   COMMENT  WCS header keyrecords produced by WCSLIB 5.9                           "
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,14 @@ worldcoords = pix_to_world(wcs, pixcoords[:, 1])
 pixcoords_out = world_to_pix(wcs, worldcoords)
 @test maximum(abs(pixcoords_out .- pixcoords[:, 1])) < 1e-9
 
+# Test retrieving attributes
+@test wcs[:ctype] == ["RA---AIR", "DEC--AIR"]
+@test wcs[:dateavg] == ""
+@test wcs[:alt] == 'B'
+@test wcs[:cdelt] == [-0.066667, 0.066667]
+@test wcs[:cd] == [0.0 0.0; 0.0 0.0]
+@test wcs[:obsgeo] == (1.0, 2.0, 3.0)
+
 header = "SIMPLE  =                    T / file does conform to FITS standard             BITPIX  =                  -64 / number of bits per data pixel                  NAXIS   =                    2 / number of data axes                            NAXIS1  =                 3636 / length of data axis 1                          NAXIS2  =                 1939 / length of data axis 2                          EXTEND  =                    T / FITS dataset may contain extensions            COMMENT   FITS (Flexible Image Transport System) format is defined in 'AstronomyCOMMENT   and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H WCSAXES =                    2 / Number of coordinate axes                      CRPIX1  =               1818.0 / Pixel coordinate of reference point            CRPIX2  =                969.5 / Pixel coordinate of reference point            CDELT1  =             -0.00825 / [deg] Coordinate increment at reference point  CDELT2  =              0.00825 / [deg] Coordinate increment at reference point  CUNIT1  = 'deg'                / Units of coordinate increment and value        CUNIT2  = 'deg'                / Units of coordinate increment and value        CTYPE1  = 'RA---CEA'           / Right ascension, cylindrical equal area projectCTYPE2  = 'DEC--CEA'           / Declination, cylindrical equal area projection CRVAL1  =            3.575E+02 / [deg] Coordinate value at reference point      CRVAL2  =            0.000E+00 / [deg] Coordinate value at reference point      PV2_1   =                  1.0 / CEA projection parameter                       LONPOLE =                  0.0 / [deg] Native longitude of celestial pole       LATPOLE =                 90.0 / [deg] Native latitude of celestial pole        RADESYS = 'ICRS'               / Equatorial coordinate system                                                                                                   COMMENT  WCS header keyrecords produced by WCSLIB 5.9                           "
 
 ws = WCS.from_header(header)


### PR DESCRIPTION
This does two things:

1. Generalize `world_to_pix` and `pix_to_world` so that a single set of coordinates (1-d array) works.
2. Implement `getindex` for `WCSTransform` so that, e.g., `wcs[:ctype]` returns the CTYPE attribute. This is consistent with setting attributes with `wcs[:ctype] = ...`.