### PR TITLE
julia 0.4 --> 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
   - osx
   - linux
 julia:
-  - nightly
   - 0.4
+  - nightly
 notifications:
   email: false
 script:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.4
-BinDeps
+BinDeps 0.4.1
+Compat 0.8.6


### PR DESCRIPTION
Hi @kbarbary -- I made a fork of WCS.jl that gets rid of the latest deprecated warning from Julia 0.5. It isn't backward compatible with 0.4 but I thought I'd submit the PR in case you wanted to merge it anyway.  (Presumably users still on 0.4 would fetch the latest tagged version that's compatible with their version of Julia if they do `Pkg.add("WCS")`. )