### PR TITLE
Clear deprecation warnings in Julia 0.7

### DIFF
--- a/src/WCS.jl
+++ b/src/WCS.jl
@@ -52,7 +52,7 @@ function convert_string{N}(::Type{Compat.ASCIIString}, v::NTuple{N, UInt8})
             break
         end
     end
-    s = Array(UInt8, len)
+    s = Array{UInt8}(len)
     copy!(s, 1, v, 1, len)
     return Compat.ASCIIString(s)  # wraps the array `s`
 end
@@ -104,7 +104,7 @@ function assert_ok(i::Cint)
 end
 
 function wcslib_version()
-    vers = Array(Cint, 3)
+    vers = Array{Cint}(3)
     ccall((:wcslib_version, libwcs), Ptr{UInt8}, (Ptr{Cint},), vers)
     return VersionNumber(vers[1], vers[2], vers[3])
 end
@@ -113,10 +113,10 @@ end
 # WCSTransform
 
 # mirror of `struct pvcard`
-typealias PVCard Tuple{Cint, Cint, Cdouble}  # i, m, value entries
+const PVCard = Tuple{Cint, Cint, Cdouble}  # i, m, value entries
 
 # mirror of `struct pscard`
-typealias PSCard Tuple{Cint, Cint, NTuple{72, UInt8}}  # i, m, value entries
+const PSCard = Tuple{Cint, Cint, NTuple{72, UInt8}}  # i, m, value entries
 
 # mirror of `struct wcserr`
 immutable WCSErr
@@ -350,13 +350,13 @@ function getindex(wcs::WCSTransform, k::Symbol)
 
     # double[naxis]
     if k in (:cdelt, :crder, :crota, :crpix, :crval, :csyer)
-        v = Array(Float64, naxis)
+        v = Array{Float64}(naxis)
         unsafe_copy!(pointer(v), getfield(wcs,k), naxis)
 
     # char[72,naxis]
     elseif k in (:cname, :ctype, :cunit)
         p = convert(Ptr{UInt8}, getfield(wcs, k))
-        v = Array(Compat.ASCIIString, naxis)
+        v = Array{Compat.ASCIIString}(naxis)
         for i=1:naxis
             pi = p + 72*(i-1)  # Ptr{UInt8} to the i-th entry.
             v[i] = convert_string(Compat.ASCIIString, pi, 72)
@@ -372,7 +372,7 @@ function getindex(wcs::WCSTransform, k::Symbol)
 
     # double[naxis,naxis]
     elseif k in (:cd, :pc)
-        v = Array(Cdouble, naxis, naxis)
+        v = Array{Cdouble}(naxis, naxis)
         unsafe_copy!(pointer(v), getfield(wcs,k), naxis*naxis)
 
     # double

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@
 
 using WCS
 using Base.Test
+using Compat
 
 wcs = WCSTransform(2;
                    alt     = 'B',
@@ -24,15 +25,15 @@ worldcoords = pix_to_world(wcs, pixcoords)
 expected_world = [267.96547027 276.53931377 287.77080792;
                   -73.73660749 -71.97412809 -69.67813884]
 
-@test maximum(abs(worldcoords .- expected_world)) < 5e-9
+@test @compat maximum(abs.(worldcoords .- expected_world)) < 5e-9
 pixcoords_out = world_to_pix(wcs, worldcoords)
-@test maximum(abs(pixcoords_out .- pixcoords)) < 1e-9
+@test @compat maximum(abs.(pixcoords_out .- pixcoords)) < 1e-9
 
 # Test Array{Float64, 1} methods of above
 worldcoords = pix_to_world(wcs, pixcoords[:, 1])
-@test maximum(abs(worldcoords .- expected_world[:, 1])) < 5e-9
+@test @compat maximum(abs.(worldcoords .- expected_world[:, 1])) < 5e-9
 pixcoords_out = world_to_pix(wcs, worldcoords)
-@test maximum(abs(pixcoords_out .- pixcoords[:, 1])) < 1e-9
+@test @compat maximum(abs.(pixcoords_out .- pixcoords[:, 1])) < 1e-9
 
 # Test retrieving attributes
 @test wcs[:ctype] == ["RA---AIR", "DEC--AIR"]


### PR DESCRIPTION
<s>There are still warnings like
```
WARNING: abs{T <: Number}(x::AbstractArray{T}) is deprecated, use abs.(x) instead.
```
but that would require dropping support for Julia 0.4 in order to clear them.  Anyway, `abs(array)` is used only in tests, the source code shouldn't have deprecations.</s>

Also warnings in the tests have been cleared, using `@compat`.