### PR TITLE
Drop support for Julia 0.4 and clear deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
   - osx
   - linux
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.4
+julia 0.5
 BinDeps 0.4.1
-Compat 0.8.6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@
 
 using WCS
 using Base.Test
-using Compat
 
 wcs = WCSTransform(2;
                    alt     = 'B',
@@ -25,15 +24,15 @@ worldcoords = pix_to_world(wcs, pixcoords)
 expected_world = [267.96547027 276.53931377 287.77080792;
                   -73.73660749 -71.97412809 -69.67813884]
 
-@test @compat maximum(abs.(worldcoords .- expected_world)) < 5e-9
+@test maximum(abs.(worldcoords .- expected_world)) < 5e-9
 pixcoords_out = world_to_pix(wcs, worldcoords)
-@test @compat maximum(abs.(pixcoords_out .- pixcoords)) < 1e-9
+@test maximum(abs.(pixcoords_out .- pixcoords)) < 1e-9
 
 # Test Array{Float64, 1} methods of above
 worldcoords = pix_to_world(wcs, pixcoords[:, 1])
-@test @compat maximum(abs.(worldcoords .- expected_world[:, 1])) < 5e-9
+@test maximum(abs.(worldcoords .- expected_world[:, 1])) < 5e-9
 pixcoords_out = world_to_pix(wcs, worldcoords)
-@test @compat maximum(abs.(pixcoords_out .- pixcoords[:, 1])) < 1e-9
+@test maximum(abs.(pixcoords_out .- pixcoords[:, 1])) < 1e-9
 
 # Test retrieving attributes
 @test wcs[:ctype] == ["RA---AIR", "DEC--AIR"]
@@ -66,3 +65,7 @@ header_out = WCS.to_header(w)
 # Test propagating errors from wcslib.
 # TODO: replace this with a public WCS routine that throws an error.
 @test_throws ErrorException WCS.assert_ok(Cint(1))
+
+@testset "ASCII strings" begin
+    @test_throws AssertionError WCS.convert_string(NTuple{72, UInt8}, "àèìoù")
+end


### PR DESCRIPTION
`Compat` doesn't support Julia 0.4 anymore, do the same here as well.

Like in https://github.com/JuliaAstro/FITSIO.jl/pull/72, new `String` doesn't the string is ASCII only, should this be necessary must be tested with `isascii`.