### PR TITLE
Improve Thread/Interrupt Safety

### DIFF
--- a/src/WCS.jl
+++ b/src/WCS.jl
@@ -806,7 +806,6 @@ function from_header(header::String; relax::Integer = HDR_ALL, ctrl::Integer = 0
         end
         return status
     end
-    @show status
     assert_ok(status)
     p = wcsptr[]
     result = WCSTransform[unsafe_load(p, i) for i = 1:nwcs[]]
@@ -825,7 +824,6 @@ function from_header(header::String; relax::Integer = HDR_ALL, ctrl::Integer = 0
         for w in result
             finalizer(free!, w)
             status = ccall((:wcsset, libwcs), Cint, (Ref{WCSTransform},), w)
-            @show status
             assert_ok(status)
         end
     end

--- a/src/WCS.jl
+++ b/src/WCS.jl
@@ -790,21 +790,22 @@ function from_header(header::String; relax::Integer = HDR_ALL, ctrl::Integer = 0
 
     # wcsbth & wcspih are not thread-safe; see
     # http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/threads.html
-    lock(wcs_lock)
-    if table
-        colsel = convert(Ptr{Cint}, C_NULL)
-        status = ccall((:wcsbth, libwcs), Cint,
-                       (Ptr{UInt8}, Cint, Cint, Cint, Cint, Ptr{Cint},
-                        Ref{Cint}, Ref{Cint}, Ref{Ptr{WCSTransform}}),
-                       header, nkeyrec, relax, ctrl, keysel, colsel,
-                       nreject, nwcs, wcsptr)
-    else
-        status = ccall((:wcspih, libwcs), Cint,
-                       (Ptr{UInt8}, Cint, Cint, Cint, Ref{Cint}, Ref{Cint},
-                        Ref{Ptr{WCSTransform}}),
-                       header, nkeyrec, relax, ctrl, nreject, nwcs, wcsptr)
+    status = lock(wcs_lock) do 
+        if table
+            colsel = convert(Ptr{Cint}, C_NULL)
+            status = ccall((:wcsbth, libwcs), Cint,
+                        (Ptr{UInt8}, Cint, Cint, Cint, Cint, Ptr{Cint},
+                            Ref{Cint}, Ref{Cint}, Ref{Ptr{WCSTransform}}),
+                        header, nkeyrec, relax, ctrl, keysel, colsel,
+                        nreject, nwcs, wcsptr)
+        else
+            status = ccall((:wcspih, libwcs), Cint,
+                        (Ptr{UInt8}, Cint, Cint, Cint, Ref{Cint}, Ref{Cint},
+                            Ref{Ptr{WCSTransform}}),
+                        header, nkeyrec, relax, ctrl, nreject, nwcs, wcsptr)
+        end
+        return status
     end
-    unlock(wcs_lock)
     assert_ok(status)
     p = wcsptr[]
     result = WCSTransform[unsafe_load(p, i) for i = 1:nwcs[]]
@@ -819,13 +820,13 @@ function from_header(header::String; relax::Integer = HDR_ALL, ctrl::Integer = 0
     # For each of the WCSTransforms, register a finalizer and finish
     # initialization of the struct by calling wcsset. This avoids race
     # conditions between threads using the same WCSTransform.
-    lock(wcs_lock)
-    for w in result
-        finalizer(free!, w)
-        status = ccall((:wcsset, libwcs), Cint, (Ref{WCSTransform},), w)
-        assert_ok(status)
+    lock(wcs_lock) do 
+        for w in result
+            finalizer(free!, w)
+            status = ccall((:wcsset, libwcs), Cint, (Ref{WCSTransform},), w)
+            assert_ok(status)
+        end
     end
-    unlock(wcs_lock)
 
     if !ignore_rejected && nreject[] != 0
         error("$(nreject[]) WCS transformations were rejected; " *

--- a/src/WCS.jl
+++ b/src/WCS.jl
@@ -863,13 +863,3 @@ function Base.setindex!(wcs::WCSTransform, v, k::Symbol)
 end
 
 end  # module
-
-
-function __init__()
-
-    # Redirect error message from stderr to internal string buffer
-    ccall((:wcsprintf_set, libwcs), Cvoid, (Ptr{Nothing},), C_NULL)
-
-    # Enable verbose error logging system
-    ccall((:wcserr_enable, libwcs), Cvoid, (Cint,), 1)
-end


### PR DESCRIPTION
This PR changes the `wcs_lock` from a `SpinLock` to a `ReentrantLock`, and changes how that lock is used to prevent deadlocks.

Currently, it's possible to interrupt this library between calling `lock(wcs_lock)` and `unlock(wcs_lock)`. If that happens, it remains locked and the next call to `lock(wcs_lock)` deadlocks.

