### PR TITLE
switch to WCS 7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,10 @@
 name = "WCS"
 uuid = "15f3aee2-9e10-537f-b834-a6fb8bdb944d"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 WCS_jll = "550c8279-ae0e-5d1b-948f-937f2608a23e"
 
 [compat]
-WCS_jll = "6.4"
+WCS_jll = "7"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "WCS"
 uuid = "15f3aee2-9e10-537f-b834-a6fb8bdb944d"
-version = "0.5.2"
+version = "0.6.0"
 
 [deps]
 WCS_jll = "550c8279-ae0e-5d1b-948f-937f2608a23e"

--- a/src/WCS.jl
+++ b/src/WCS.jl
@@ -366,6 +366,7 @@ mutable struct WCSTransform
     zsource::Cdouble
     ssyssrc::NTuple{72,UInt8}
     velangl::Cdouble
+    aux::Ptr{Cvoid}  # Ptr{auxprm}
     ntab::Cint
     nwtb::Cint
     tab::Ptr{Cvoid}  # Ptr{tabprm}
@@ -399,6 +400,7 @@ mutable struct WCSTransform
     m_csyer::Ptr{Cdouble}
     m_czphs::Ptr{Cdouble}
     m_cperi::Ptr{Cdouble}
+    m_aux::Ptr{Cvoid}  # Ptr{auxprm}
     m_tab::Ptr{Cvoid}  # Ptr{tabprm}
     m_wtb::Ptr{Cvoid}  # Ptr{wtbarr}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,7 +68,7 @@ end
     # between minor WCSLIB versions. For example,
     # `0.0E+00` vs `0.000E+00`.)
     header_out = WCS.to_header(w)
-    @test length(header_out) == 17 * 80
+    @test length(header_out) == 18 * 80
 
     # test relax keyword
     faulty_header = replace(header, "RADESYS = 'ICRS'" => "RADECSYS= 'FK5' ")


### PR DESCRIPTION
- update to WCS 7

This currently is failing the tests. `WCS.from_header()` is throwing `malloc` errors:
```
julia(71539,0x1181bbe00) malloc: *** error for object 0xffffffffffffffff: pointer being freed was not allocated
julia(71539,0x1181bbe00) malloc: *** set a breakpoint in malloc_error_break to debug

signal (6): Abort trap: 6
in expression starting at none:0
__pthread_kill at /usr/lib/system/libsystem_kernel.dylib (unknown line)
Allocations: 3936464 (Pool: 3935092; Big: 1372); GC: 4
ERROR: Package WCS errored during testing (received signal: 6)
```
it's possible `WCS.to_header()` is also broken.

In addition, the `header_out` length has changed from `17 * 80` to `18 * 80`, although I'm not sure if that's intended given the malloc errors, so I haven't changed it.
