### PR TITLE
conversions: fix array sizes and return all outputs

### DIFF
--- a/src/WCS.jl
+++ b/src/WCS.jl
@@ -690,12 +690,16 @@ to store intermediate results. Their sizes and types must all match
 `pixcoords`, except for `stat` which should be the same size but of type
 Cint (typically Int32).
 """
-function pix_to_world!(wcs::WCSTransform, pixcoords::VecOrMat{Float64},
-                       worldcoords::VecOrMat{Float64};
-                       stat = similar(pixcoords, Cint),
+pix_to_world!(wcs::WCSTransform, pixcoords, worldcoords; kwargs...) =
+    pix_to_world_full(wcs, pixcoords, worldcoords; kwargs...).worldcoords
+
+
+function pix_to_world_full(wcs::WCSTransform, pixcoords::VecOrMat{Float64},
+                       worldcoords::VecOrMat{Float64}=similar(pixcoords),
+                       stat = similar(pixcoords, Cint, size(pixcoords, 2)),
                        imcoords = similar(pixcoords),
-                       phi = similar(pixcoords),
-                       theta = similar(pixcoords))
+                       phi = similar(pixcoords, size(pixcoords, 2)),
+                       theta = similar(pixcoords, size(pixcoords, 2)))
     nelem = size(pixcoords, 1)
     ncoords = size(pixcoords, 2)
     if nelem < wcs.naxis
@@ -703,15 +707,13 @@ function pix_to_world!(wcs::WCSTransform, pixcoords::VecOrMat{Float64},
     end
     @same_size worldcoords pixcoords
     @same_size imcoords pixcoords
-    @same_size phi pixcoords
-    @same_size theta pixcoords
-    @same_size stat pixcoords
     ccall((:wcsp2s, libwcs), Cint,
           (Ref{WCSTransform}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble},
            Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}),
           wcs, ncoords, nelem, pixcoords, imcoords, phi, theta, worldcoords,
           stat)
-    return worldcoords
+    return (; pixcoords=pixcoords, worldcoords=worldcoords,
+              stat=stat, imcoords=imcoords, phi=phi, theta=theta)
 end
 
 
@@ -745,11 +747,15 @@ to store intermediate results. Their sizes and types must all match
 `worldcoords`, except for `stat` which should be the same size but of type
 Cint (typically Int32).
 """
-function world_to_pix!(wcs::WCSTransform, worldcoords::VecOrMat{Float64},
-                       pixcoords::VecOrMat{Float64};
-                       stat = similar(pixcoords, Cint),
-                       phi = similar(pixcoords),
-                       theta = similar(pixcoords),
+world_to_pix!(wcs::WCSTransform, worldcoords, pixcoords; kwargs...) =
+    world_to_pix_full(wcs, worldcoords, pixcoords; kwargs...).pixcoords
+
+
+function world_to_pix_full(wcs::WCSTransform, worldcoords::VecOrMat{Float64},
+                       pixcoords::VecOrMat{Float64}=similar(worldcoords);
+                       stat = similar(pixcoords, Cint, size(worldcoords, 2)),
+                       phi = similar(pixcoords, size(worldcoords, 2)),
+                       theta = similar(pixcoords, size(worldcoords, 2)),
                        imcoords = similar(pixcoords))
     nelem = size(worldcoords, 1)
     ncoords = size(worldcoords, 2)
@@ -758,15 +764,13 @@ function world_to_pix!(wcs::WCSTransform, worldcoords::VecOrMat{Float64},
     end
     @same_size pixcoords worldcoords
     @same_size imcoords worldcoords
-    @same_size phi worldcoords
-    @same_size theta worldcoords
-    @same_size stat worldcoords
     ccall((:wcss2p, libwcs), Cint,
           (Ref{WCSTransform}, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble},
            Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}),
           wcs, ncoords, nelem, worldcoords, phi, theta, imcoords, pixcoords,
           stat)
-    return pixcoords
+    return (; pixcoords=pixcoords, worldcoords=worldcoords,
+              stat=stat, imcoords=imcoords, phi=phi, theta=theta)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,21 @@ wcs = WCSTransform(2;
     @test maximum(abs.(worldcoords .- expected_world[:, 1])) < 5e-9
     pixcoords_out = world_to_pix(wcs, worldcoords)
     @test maximum(abs.(pixcoords_out .- pixcoords[:, 1])) < 1e-9
+
+    p2w = WCS.pix_to_world_full(wcs, pixcoords[:, 1])
+    @test p2w.pixcoords == pixcoords[:, 1]
+    @test p2w.worldcoords ≈ expected_world[:, 1]
+    @test p2w.stat == [0]
+    @test p2w.imcoords ≈ [-15.65007825, -0.5559561131]
+    @test p2w.phi ≈ [-87.96547027027647]
+    @test p2w.theta ≈ [73.73660748999083]
+    w2p = WCS.world_to_pix_full(wcs, worldcoords)
+    @test w2p.pixcoords ≈ [0, 0]  atol=1e-10
+    @test w2p.worldcoords ≈ expected_world[:, 1]
+    @test w2p.stat == [0]
+    @test w2p.imcoords ≈ [-15.65007825, -0.5559561131]
+    @test w2p.phi ≈ [-87.96547027027647]
+    @test w2p.theta ≈ [73.73660748999083]
 end
 
 @testset "getproperty" begin


### PR DESCRIPTION
Some arrays (phi, theta, stat) passed to `wcsp2s` should have one entry per coordinate, not per coordinate component. See https://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/wcs_8h.html.
The remaining entries of those arrays contained garbage. This PR fixes it.

Also, add internal functions to return all conversion outputs from `libwcs`. Sometimes, this is convenient when debugging.