### PR TITLE
Hold off on separate doc tests in CI

### DIFF
--- a/test/test_docs.jl
+++ b/test/test_docs.jl
@@ -1,6 +1,6 @@
-using Documenter: DocMeta, doctest
-
-@testset "Doctests" begin
-    DocMeta.setdocmeta!(WCS, :DocTestSetup, :(using WCS); recursive=true)
-    doctest(WCS)
-end
+#using Documenter: DocMeta, doctest
+#
+#@testset "Doctests" begin
+#    DocMeta.setdocmeta!(WCS, :DocTestSetup, :(using WCS); recursive=true)
+#    doctest(WCS)
+#end


### PR DESCRIPTION
Commenting out separate CI docs test until https://github.com/JuliaTesting/ParallelTestRunner.jl/issues/68 is resolved

Related discussion: https://github.com/JuliaAstro/Spectra.jl/pull/38